### PR TITLE
Replace Location address fld with multiple primitive flds

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,11 +1,8 @@
 {
   "orgName": "pablo company",
   "edition": "Developer",
-  "features": ["EnableSetPasswordInApi", "StateAndCountryPicklist"],
+  "features": ["EnableSetPasswordInApi"],
   "settings": {
-    "customAddressFieldSettings": {
-      "enableCustomAddressField": true
-    },
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true
     },

--- a/force-app/main/default/objects/Resume__c/fields/Location_Address__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume__c/fields/Location_Address__c.field-meta.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Location__c</fullName>
-    <label>Location</label>
+    <fullName>Location_Address__c</fullName>
+    <label>Address</label>
+    <required>false</required>
     <trackTrending>false</trackTrending>
-    <type>Address</type>
+    <type>TextArea</type>
 </CustomField>

--- a/force-app/main/default/objects/Resume__c/fields/Location_City__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume__c/fields/Location_City__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Location_City__c</fullName>
+    <externalId>false</externalId>
+    <label>City</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Resume__c/fields/Location_CountryCode__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume__c/fields/Location_CountryCode__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Location_CountryCode__c</fullName>
+    <externalId>false</externalId>
+    <label>CountryCode</label>
+    <length>2</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Resume__c/fields/Location_PostalCode__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume__c/fields/Location_PostalCode__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Location_PostalCode__c</fullName>
+    <externalId>false</externalId>
+    <label>PostalCode</label>
+    <length>20</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Resume__c/fields/Location_Region__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume__c/fields/Location_Region__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Location_Region__c</fullName>
+    <externalId>false</externalId>
+    <inlineHelpText>State, Province, etc.</inlineHelpText>
+    <label>Region</label>
+    <length>40</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Remove `Location__c` address field, since Custom Address fields are not supported in Unlocked Packages.
Instead, add separate location fields.
